### PR TITLE
Q-command is not performed when 'sq' is typed (start of 'sqrt')

### DIFF
--- a/UniversalConsole/CommandProcessor/Executables.cs
+++ b/UniversalConsole/CommandProcessor/Executables.cs
@@ -540,7 +540,7 @@ namespace UniversalConsole.CommandProcessor
                     while (true)
                     {
                         ConsoleKeyInfo i = Console.ReadKey();
-                        if (i.Key == ConsoleKey.Q)
+                        if (i.Key == ConsoleKey.Q && !(input.EndsWith('s') || input.EndsWith('S')))
                         {
                             Console.WriteLine();
                             return true;


### PR DESCRIPTION
q command means exit from the calculator. But when it is a part of the 'sqrt' command, it must not trigger the exit.